### PR TITLE
Missing default for accent

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rose Pine",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "minAppVersion": "1.0.0",
   "author": "rose-pine",
   "authorUrl": "https://github.com/JTrenerry"

--- a/src/themes.css
+++ b/src/themes.css
@@ -97,6 +97,8 @@
   --rp-h5: var(--rp-foam);
   --rp-h6: var(--rp-pine);
 
+  --rp-accent: var(--rp-iris);
+
   --inline-code: var(--rp-iris);
   --code-block: var(--rp-foam);
   --pre-code: var(--rp-highlightLow);


### PR DESCRIPTION
There was a missing default for accent when not using style settings, as a result highlighting wasn't working.

Fixes #31 