### PR TITLE
Fixed Bold Inline Code Rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 theme.css
-*example.css

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 theme.css
+*example.css

--- a/src/theme.css
+++ b/src/theme.css
@@ -171,6 +171,19 @@ strong kbd {
   -webkit-text-fill-color: initial;
 }
 
+.cm-strong span.cm-inline-code,
+strong code {
+  -webkit-text-fill-color: var(--rp-love) !important;
+  color: var(--rp-love) !important;
+  font-weight: bold !important;
+}
+
+.cm-strong span.cm-inline-code::selection,
+strong code::selection {
+  -webkit-text-fill-color: inherit !important;
+}
+
+
 .cm-s-obsidian span.cm-formatting-list {
   color: var(--text-normal) !important;
 }
@@ -465,7 +478,7 @@ ul .task-list-item ul::before {
   border: 0px !important;
 }
 
-an active line highlight in vim normal mode
+/* an active line highlight in vim normal mode */
 .cm-fat-cursor .CodeMirror-activeline .CodeMirror-linebackground{
   background-color: var(--text-selection) !important;
 }
@@ -473,7 +486,6 @@ an active line highlight in vim normal mode
 code {
   color: var(--inline-code) !important;
   bottom: 0px !important;
-  color:
 }
 
 .graph-view.color-arrow {

--- a/theme.css
+++ b/theme.css
@@ -566,6 +566,16 @@ strong::selection {
 strong kbd {
   -webkit-text-fill-color: initial;
 }
+.cm-strong span.cm-inline-code,
+strong code {
+  -webkit-text-fill-color: var(--rp-love) !important;
+  color: var(--rp-love) !important;
+  font-weight: bold !important;
+}
+.cm-strong span.cm-inline-code::selection,
+strong code::selection {
+  -webkit-text-fill-color: inherit !important;
+}
 .cm-s-obsidian span.cm-formatting-list {
   color: var(--text-normal) !important;
 }
@@ -799,14 +809,12 @@ ul .task-list-item ul::before {
 .HyperMD-codeblock-bg {
   border: 0px !important;
 }
-an active line highlight in vim normal mode
 .cm-fat-cursor .CodeMirror-activeline .CodeMirror-linebackground{
   background-color: var(--text-selection) !important;
 }
 code {
   color: var(--inline-code) !important;
   bottom: 0px !important;
-  color:
 }
 .graph-view.color-arrow {
   color: var(--rp-pine);


### PR DESCRIPTION
When setting an inline code section as bold and changing to reading mode you loose the text. 
Changed the text to just some ping color.

Here's what the error look like (First image editing mode, second reading mode)

<img width="404" height="81" alt="image" src="https://github.com/user-attachments/assets/32106a8a-016f-4542-a2d4-12cddbba200f" />


<img width="373" height="65" alt="image" src="https://github.com/user-attachments/assets/65b91363-9b9b-4f9a-883c-0467456a6036" />

Here's how it looks with the code applied.

<img width="381" height="66" alt="image" src="https://github.com/user-attachments/assets/15bf65c5-474e-497d-a09e-ed81dfe552ee" />

Also, I'm so sorry for the .gitignore editing. I do not know how to delete it from the PR. Please feel free to do so.
